### PR TITLE
chore(package.json): include only dist folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
   "engines": {
     "node": ">=12.0.0"
   },
+  "files": [
+    "dist"
+  ],
   "homepage": "https://github.com/cartant/eslint-plugin-rxjs-angular",
   "husky": {
     "hooks": {


### PR DESCRIPTION
Thanks for making this really useful ESLint plugin!

The current package includes some development files and docs which are not necessary for distribution.

It also causes some error messages in VSCode from the ESLint plugin:
> ESLint server is starting
> ESLint server running in node v12.14.1
> ESLint server is running.
> ESLint library loaded from: /<myproject>/node_modules/eslint/lib/api.js
> Failed to load config "@cartant/eslint-config" to extend from. Referenced from: /<myproject>/node_modules/eslint-plugin-rxjs-angular/.eslintrc.json

Adding the `files` property in `package.json` indicates which folder/files should be packaged.

Before:
```shell
package size:  7.7 kB                                  
unpacked size: 14.9 kB   
```

After: 
```shell
package size:  2.7 kB                                  
unpacked size: 6.7 kB   
```