### PR TITLE
Added superClass option. Fixes #1

### DIFF
--- a/docs/rules/prefer-composition.md
+++ b/docs/rules/prefer-composition.md
@@ -48,7 +48,11 @@ export class SomeComponent implements OnInit, OnDestroy {
 
 ## Options
 
-This rule accepts a single option which is an object with a `checkDecorators` property which is an array containing the names of the decorators that determine whether or not a class is checked. By default, `checkDecorators` is `["Component"]`.
+This rule accepts a single option which is an object with a `checkDecorators` and `superClass` properties.
+
+The `checkDecorators` property is an array containing the names of the decorators that determine whether or not a class is checked. By default, `checkDecorators` is `["Component"]`.
+
+The `superClass` property is an array containing the names of classes to extend from that already implements a `Subject`-based `ngOnDestroy`.
 
 ```json
 {

--- a/docs/rules/prefer-takeuntil.md
+++ b/docs/rules/prefer-takeuntil.md
@@ -50,11 +50,15 @@ class SomeComponent implements OnDestroy, OnInit {
 
 ## Options
 
-This rule accepts a single option which is an object with `checkComplete`, `checkDecorators`, `checkDestroy` and `alias` properties.
+This rule accepts a single option which is an object with `checkComplete`, `checkDecorators`, `checkDestroy`, `superClass` and `alias` properties.
 
 The `checkComplete` property is a boolean that determines whether or not `complete` must be called after `next` and the `checkDestroy` property is a boolean that determines whether or not a `Subject`-based `ngOnDestroy` must be implemented.
 
 The `checkDecorators` property is an array containing the names of the decorators that determine whether or not a class is checked. By default, `checkDecorators` is `["Component"]`.
+
+The `checkDestroy` property is a boolean that determines whether or not a `Subject`-based `ngOnDestroy` must be implemented.
+
+The `superClass` property is an array containing the names of classes to extend from that already implements a `Subject`-based `ngOnDestroy`.
 
 The `alias` property is an array of names of operators that should be treated similarly to `takeUntil`.
 
@@ -66,7 +70,8 @@ The `alias` property is an array of names of operators that should be treated si
       "alias": ["untilDestroyed"],
       "checkComplete": true,
       "checkDecorators": ["Component"],
-      "checkDestroy": true
+      "checkDestroy": true,
+      "superClass": []
     }
   ]
 }

--- a/tests/rules/prefer-composition.ts
+++ b/tests/rules/prefer-composition.ts
@@ -98,6 +98,44 @@ ruleTester({ types: true }).run("prefer-composition", rule, {
         }
       `,
     },
+    {
+      code: stripIndent`
+        // extends superClass
+        // https://github.com/cartant/eslint-plugin-rxjs-angular/issues/1
+        import { Component, Directive, OnDestroy } from "@angular/core";
+        import { of, Subject } from "rxjs";
+        import { switchMap, takeUntil } from "rxjs/operators";
+
+        const o = of("o");
+
+        @Directive()
+        abstract class BaseComponent implements OnDestroy {
+          private readonly destroySubject = new Subject<void>();
+          protected readonly destroy = this.destroySubject.asObservable();
+          ngOnDestroy() {
+            this.destroySubject.next();
+            this.destroySubject.complete();
+          }
+        }
+
+        @Component({
+          selector: "component-with-super-class"
+        })
+        class CorrectComponent extends BaseComponent {
+          someMethod() {
+            o.pipe(
+              switchMap(_ => o),
+              takeUntil(this.destroy)
+            ).subscribe();
+          }
+        }
+      `,
+      options: [
+        {
+          superClass: ["BaseComponent"],
+        },
+      ],
+    },
   ],
   invalid: [
     fromFixture(

--- a/tests/rules/prefer-takeuntil.ts
+++ b/tests/rules/prefer-takeuntil.ts
@@ -369,6 +369,90 @@ ruleTester({ types: true }).run("prefer-takeuntil", rule, {
         },
       ],
     },
+    {
+      code: stripIndent`
+        // extends superClass
+        // https://github.com/cartant/eslint-plugin-rxjs-angular/issues/1
+        import { Component, Directive, OnDestroy } from "@angular/core";
+        import { of, Subject } from "rxjs";
+        import { switchMap, takeUntil } from "rxjs/operators";
+
+        const o = of("o");
+
+        @Directive()
+        abstract class BaseComponent implements OnDestroy {
+          private readonly destroySubject = new Subject<void>();
+          protected readonly destroy = this.destroySubject.asObservable();
+
+          ngOnDestroy() {
+            this.destroySubject.next();
+            this.destroySubject.complete();
+          }
+        }
+
+        @Component({
+          selector: "component-with-super-class"
+        })
+        class CorrectComponent extends BaseComponent {
+          someMethod() {
+            o.pipe(
+              switchMap(_ => o),
+              takeUntil(this.destroy)
+            ).subscribe();
+          }
+        }
+      `,
+      options: [
+        {
+          superClass: ["BaseComponent"],
+          checkComplete: true,
+        },
+      ],
+    },
+    {
+      code: stripIndent`
+        // extends superClass and implements OnDestroy
+        // https://github.com/cartant/eslint-plugin-rxjs-angular/issues/1
+        import { Component, Directive, OnDestroy } from "@angular/core";
+        import { of, Subject } from "rxjs";
+        import { switchMap, takeUntil } from "rxjs/operators";
+
+        const o = of("o");
+
+        @Directive()
+        abstract class BaseComponent implements OnDestroy {
+          private readonly destroySubject = new Subject<void>();
+          protected readonly destroy = this.destroySubject.asObservable();
+
+          ngOnDestroy() {
+            this.destroySubject.next();
+            this.destroySubject.complete();
+          }
+        }
+
+        @Component({
+          selector: "component-with-super-class-and-destroy"
+        })
+        class CorrectDestroyComponent extends BaseComponent implements OnDestroy {
+          someMethod() {
+            o.pipe(
+              switchMap(_ => o),
+              takeUntil(this.destroy)
+            ).subscribe();
+          }
+
+          override ngOnDestroy(): void {
+            super.ngOnDestroy()
+          }
+        }
+      `,
+      options: [
+        {
+          superClass: ["BaseComponent"],
+          checkComplete: true,
+        },
+      ],
+    },
   ],
   invalid: [
     fromFixture(
@@ -653,6 +737,90 @@ ruleTester({ types: true }).run("prefer-takeuntil", rule, {
         options: [
           {
             checkDecorators: ["Component", "Pipe", "Injectable", "Directive"],
+          },
+        ],
+      }
+    ),
+    fromFixture(
+      stripIndent`
+        // extends superClass and implements OnDestroy, missing super.ngOnDestroy()
+        // https://github.com/cartant/eslint-plugin-rxjs-angular/issues/1
+        import { Component, Directive, OnDestroy } from "@angular/core";
+        import { of, Subject } from "rxjs";
+        import { switchMap, takeUntil } from "rxjs/operators";
+
+        const o = of("o");
+
+        @Directive()
+        abstract class BaseComponent implements OnDestroy {
+          private readonly destroySubject = new Subject<void>();
+          protected readonly destroy = this.destroySubject.asObservable();
+
+          ngOnDestroy() {
+            this.destroySubject.next();
+            this.destroySubject.complete();
+          }
+        }
+
+        @Component({
+          selector: "missing-super-call"
+        })
+        class MissingSuperCallComponent extends BaseComponent implements OnDestroy {
+          someMethod() {
+            o.pipe(
+              switchMap(_ => o),
+              takeUntil(this.destroy)
+            ).subscribe();
+          }
+
+          override ngOnDestroy(): void {
+                   ~~~~~~~~~~~ [notCalled { "method": "ngOnDestroy", "name": "super" }]
+          }
+        }
+      `,
+      {
+        options: [
+          {
+            superClass: ["BaseComponent"],
+            checkComplete: true,
+          },
+        ],
+      }
+    ),
+    fromFixture(
+      stripIndent`
+        // Calls super.ngOnDestroy() w/o extending base class
+        // https://github.com/cartant/eslint-plugin-rxjs-angular/issues/1
+        import { Component, OnDestroy } from "@angular/core";
+        import { of } from "rxjs";
+        import { switchMap, takeUntil } from "rxjs/operators";
+
+        const o = of("o");
+
+        @Component({
+          selector: "missing-base"
+        })
+        class MissingBaseComponent extends SomeClass implements OnDestroy {
+              ~~~~~~~~~~~~~~~~~~~~ [notDeclared { "name": "destroy" }]
+          someMethod() {
+            o.pipe(
+              switchMap(_ => o),
+              takeUntil(this.destroy)
+            ).subscribe();
+          }
+
+          override ngOnDestroy(): void {
+                   ~~~~~~~~~~~ [notCalled { "method": "next", "name": "destroy" }]
+                   ~~~~~~~~~~~ [notCalled { "method": "complete", "name": "destroy" }]
+            super.ngOnDestroy()
+          }
+        }
+      `,
+      {
+        options: [
+          {
+            superClass: ["BaseComponent"],
+            checkComplete: true,
           },
         ],
       }


### PR DESCRIPTION
Updated documentation and tests (I noticed `checkDestroy` was missing from the readme as well). Ran the linter and did my best to follow what seemed to be the code style.

https://github.com/cartant/eslint-plugin-rxjs-angular/issues/1#issuecomment-1064743678

Adds the option to specify a class that components extends from which already implements the unsubscribe ngOnDestroy pattern.
Since the super class won't extend itself, this keeps everything safe. I've also considered checking for any super class by default (same logic where if the super class doesn't implement the pattern, linting would fail, just in a different location). But decided against it in the end, since someone could extend a class they don't have control over, or isn't linted. If you think it would be useful, I can add that functionality.