### PR TITLE
feat: allow typescript v5 in peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "optionalDependencies": {},
   "peerDependencies": {
     "eslint": "^8.0.0",
-    "typescript": "^4.0.0"
+    "typescript": "^4.0.0 || ^5.0.0"
   },
   "private": false,
   "publishConfig": {


### PR DESCRIPTION
Adds TypeScript v5 to the peer dependency range. TypeScript v4 is still supported for backwards compatibility. I tested in an existing Angular project, works fine.

Closes #17 