### PR TITLE
Adding excludedObservableTypes option to prefer-takeuntil

### DIFF
--- a/docs/rules/prefer-takeuntil.md
+++ b/docs/rules/prefer-takeuntil.md
@@ -58,6 +58,8 @@ The `checkDecorators` property is an array containing the names of the decorator
 
 The `alias` property is an array of names of operators that should be treated similarly to `takeUntil`.
 
+The `excludedObservableTypes` property is an array containing the names of types that should be excluded from the check.
+
 ```json
 {
   "rxjs-angular/prefer-takeuntil": [
@@ -66,7 +68,8 @@ The `alias` property is an array of names of operators that should be treated si
       "alias": ["untilDestroyed"],
       "checkComplete": true,
       "checkDecorators": ["Component"],
-      "checkDestroy": true
+      "checkDestroy": true,
+      "excludedObservableTypes": ["AsyncSubject"]
     }
   ]
 }

--- a/tests/rules/prefer-takeuntil.ts
+++ b/tests/rules/prefer-takeuntil.ts
@@ -369,6 +369,56 @@ ruleTester({ types: true }).run("prefer-takeuntil", rule, {
         },
       ],
     },
+    {
+      code: stripIndent`
+        import { Component } from "@angular/core";
+        import { AsyncSubject } from "rxjs";
+        import { switchMap } from "rxjs/operators";
+
+        const o = new AsyncSubject<string>();
+
+        @Component({
+          selector: "component-with-excluded-type-1"
+        })
+        class CorrectComponent implements OnDestroy {
+          someMethod() {
+            o.subscribe();
+          }
+        }
+      `,
+      options: [
+        {
+          excludedObservableTypes: ["AsyncSubject"],
+          checkDestroy: false,
+        },
+      ],
+    },
+    {
+      code: stripIndent`
+        import { Component } from "@angular/core";
+        import { AsyncSubject } from "rxjs";
+        import { switchMap } from "rxjs/operators";
+
+        const o = new AsyncSubject<string>();
+
+        @Component({
+          selector: "component-with-excluded-type-2"
+        })
+        class CorrectComponent implements OnDestroy {
+          someMethod() {
+            o.pipe(
+              switchMap(_ => o),
+            ).subscribe();
+          }
+        }
+      `,
+      options: [
+        {
+          excludedObservableTypes: ["AsyncSubject"],
+          checkDestroy: false,
+        },
+      ],
+    },
   ],
   invalid: [
     fromFixture(


### PR DESCRIPTION
In this PR some specific type of Observable could be excluded from being checked in prefer-takeuntil rule.

The use case for us is that we don't want to enforce this rule for AsyncSubject.